### PR TITLE
Fix team id issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "espn-api-v3"
-version = "3.0.2"
+version = "3.0.3"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -570,7 +570,9 @@ def leaderboard_change(
     return leaderboard_change
 
 
-def get_team(league: League, team_owner: str) -> Team:
+def get_team(
+    league: League, team_owner: Optional[str] = None, team_id: Optional[int] = None
+) -> Team:
     """Get the Team object corresponding to the team_owner
 
     Args:
@@ -583,11 +585,19 @@ def get_team(league: League, team_owner: str) -> Team:
     Returns:
         Team: Team object
     """
-    for team in league.teams:
-        if team.owner == team_owner:
-            return team
+    assert (team_owner is not None) or (team_id is not None)
+    if team_owner is not None:
+        for team in league.teams:
+            if team.owner == team_owner:
+                return team
 
-    raise Exception(f"Owner {team_owner} not in league.")
+        raise Exception(f"Owner {team_owner} not in league.")
+    else:
+        for team in league.teams:
+            if team.team_id == team_id:
+                return team
+
+        raise Exception(f"Team ID {team_id} not in league.")
 
 
 def get_division_standings(league: League) -> Dict[str, List[Team]]:
@@ -633,8 +643,8 @@ def game_of_the_week_stats(
         )
     )
 
-    team1 = get_team(league, owner1)
-    team2 = get_team(league, owner2)
+    team1 = get_team(league, team_owner=owner1)
+    team2 = get_team(league, team_owner=owner2)
     division_standings = get_division_standings(league)
     print("\nThis season:\n-----------------------")
     print(f"{owner1} has a record of {team1.wins}-{team1.losses}-{team1.ties}")

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -375,7 +375,6 @@ def simulate_season(
         s["team_name"] = team.team_name
         return s
 
-    breakpoint()
     playoff_odds = playoff_odds.apply(get_team_info, axis=1)
 
     return playoff_odds[

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from typing import Dict, List, Optional, Tuple
+from src.doritostats.analytic_utils import get_team
 from espn_api.football import League, Team, Matchup
 from src.doritostats.fetch_utils import PseudoMatchup
 
@@ -369,11 +370,12 @@ def simulate_season(
 
     # Add team details to the dataframe
     def get_team_info(s):
-        team = league.teams[int(s.team_id - 1)]
+        team = get_team(league, team_id=s.team_id)
         s["team_owner"] = team.owner
         s["team_name"] = team.team_name
         return s
 
+    breakpoint()
     playoff_odds = playoff_odds.apply(get_team_info, axis=1)
 
     return playoff_odds[


### PR DESCRIPTION
If a league has N teams, it is not necessarily true that the team IDs are (0, 1, 2, 3, ... N-1). Sometimes (I think if a league previously had more than N teams and then deleted some), there could be a team_id that is > N. This change gets rid of this naiive idea that team IDs are ordered.