### PR TITLE
feat: Add seeding outcomes table to simulations page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/*
 *historical_stats.csv
 *new espn.ipynb
 src/new espn.ipynb
+draft_history.csv
+src/.DS_Store

--- a/fantasy_stats/views.py
+++ b/fantasy_stats/views.py
@@ -158,7 +158,8 @@ def copy_old_league(request, league_id: int):
     )
 
 
-def league(request, league_id, league_year, week=None):
+def league(request, league_id: int, league_year: int, week: int = None):
+    # Fetch the league
     league_info = LeagueInfo.objects.get(league_id=league_id, league_year=league_year)
     league = fetch_league(
         league_info.league_id,
@@ -209,7 +210,13 @@ def all_leagues(request):
     return render(request, "fantasy_stats/all_leagues.html", {"leagues": leagues})
 
 
-def simulation(request, league_id, league_year, week=None, n_simulations=None):
+def simulation(
+    request,
+    league_id: int,
+    league_year: int,
+    week: int = None,
+    n_simulations: int = None,
+):
     if n_simulations is None:
         n_simulations = N_SIMULATIONS
 
@@ -248,7 +255,9 @@ def simulation(request, league_id, league_year, week=None, n_simulations=None):
         )
 
     else:
-        playoff_odds, rank_dist = django_simulation(league, n_simulations)
+        playoff_odds, rank_dist, seeding_outcomes = django_simulation(
+            league, n_simulations
+        )
 
     context = {
         "league_info": league_info,
@@ -256,6 +265,7 @@ def simulation(request, league_id, league_year, week=None, n_simulations=None):
         "page_week": week,
         "playoff_odds": playoff_odds,
         "rank_dist": rank_dist,
+        "seeding_outcomes": seeding_outcomes,
         "n_positions": len(league.teams),
         "positions": [ordinal(i) for i in range(1, len(league.teams) + 1)],
         "n_playoff_spots": league.settings.playoff_team_count,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "espn-api-v3"
-version = "3.0.6"
+version = "3.0.7"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/django_utils.py
+++ b/src/doritostats/django_utils.py
@@ -264,7 +264,7 @@ def django_standings(league: League):
 
 def django_simulation(league: League, n_simulations: int):
     # Get power rankings for the current week
-    playoff_odds, rank_dist = simulate_season(league, n=n_simulations)
+    playoff_odds, rank_dist, seeding_outcomes = simulate_season(league, n=n_simulations)
 
     # Infer how many teams are in the league
     n_teams = len(rank_dist)
@@ -272,7 +272,9 @@ def django_simulation(league: League, n_simulations: int):
     # Add the playoff offs and final rank distribution for each team
     django_playoff_odds = []
     django_rank_dist = []
+    django_seeding_outcomes = []
     for i in range(len(playoff_odds)):
+        # Add the odds of making the playoffs for this team
         django_playoff_odds.append(
             {
                 "team": playoff_odds.iloc[i].team_name,
@@ -302,4 +304,27 @@ def django_simulation(league: League, n_simulations: int):
             }
         )
 
-    return django_playoff_odds, django_rank_dist
+        # Add the odds of each seeding outcome for this team
+        django_seeding_outcomes.append(
+            {
+                "team": seeding_outcomes.iloc[i].team_name,
+                "owner": seeding_outcomes.iloc[i].team_owner,
+                "first_in_league": "{:.1%}".format(
+                    seeding_outcomes.iloc[i].first_in_league / 100
+                ),
+                "first_in_division": "{:.1%}".format(
+                    seeding_outcomes.iloc[i].first_in_division / 100
+                ),
+                "make_playoffs": "{:.1%}".format(
+                    seeding_outcomes.iloc[i].make_playoffs / 100
+                ),
+                "last_in_division": "{:.1%}".format(
+                    seeding_outcomes.iloc[i].last_in_division / 100
+                ),
+                "last_in_league": "{:.1%}".format(
+                    seeding_outcomes.iloc[i].last_in_league / 100
+                ),
+            }
+        )
+
+    return django_playoff_odds, django_rank_dist, django_seeding_outcomes

--- a/templates/fantasy_stats/simulation.html
+++ b/templates/fantasy_stats/simulation.html
@@ -137,6 +137,35 @@
         {% endfor %}
       <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
     </table>
+
+    <h2>Seeding outcomes</h1>
+    <table class="table">
+
+        {# Table header #}
+        <div class="row header">
+          <div class="cell">Team</div>
+          <div class="cell">Owner</div>
+          <div class="cell">1st overall</div>
+          <div class="cell">1st in division</div>
+          <div class="cell">Make playoffs</div>
+          <div class="cell">Last in division</div>
+          <div class="cell">Last overall</div>
+        </div>
+
+        {# Table elements #}
+        {% for r in seeding_outcomes %}
+        <div class="row">
+          <div class="cell" data-title="team"> {{ r.team }}</div>
+          <div class="cell" data-title="owner"> {{ r.owner }}</div>
+          <div class="cell" data-title="first_in_league"> {{ r.first_in_league }}</div>
+          <div class="cell" data-title="first_in_division"> {{ r.first_in_division }}</div>
+          <div class="cell" data-title="make_playoffs"> {{ r.make_playoffs }}</div>
+          <div class="cell" data-title="last_in_division"> {{ r.last_in_division }}</div>
+          <div class="cell" data-title="last_in_league"> {{ r.last_in_league }}</div>
+        </div>
+        {% endfor %}
+      <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
+    </table>
     </div>
     
     <footer>


### PR DESCRIPTION
A third table is added to the simulations page. This table shows the odds of the following outcomes for each team:
  *First place in the league
  * First in their division
  * Make playoffs
  * Last in their division
  * Last place in the league