### PR TITLE
fix: don't playoff odds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "espn-api-v3"
-version = "3.0.7"
+version = "3.0.8"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/django_utils.py
+++ b/src/doritostats/django_utils.py
@@ -285,7 +285,7 @@ def django_simulation(league: League, n_simulations: int):
                 "projected_points_for": "{:.1f}".format(
                     playoff_odds.iloc[i].points_for
                 ),
-                "playoff_odds": "{:.1%}".format(
+                "playoff_odds": "{:.1f}%".format(
                     playoff_odds.iloc[i].playoff_odds / 100
                 ),
             }
@@ -300,7 +300,7 @@ def django_simulation(league: League, n_simulations: int):
                 "position_odds": [
                     "{:.1%}".format(rank_dist.iloc[i][c] / 100) for c in rank_cols
                 ],
-                "playoff_odds": "{:.1%}".format(rank_dist.iloc[i].playoff_odds / 100),
+                "playoff_odds": "{:.1f}%".format(rank_dist.iloc[i].playoff_odds / 100),
             }
         )
 
@@ -315,7 +315,7 @@ def django_simulation(league: League, n_simulations: int):
                 "first_in_division": "{:.1%}".format(
                     seeding_outcomes.iloc[i].first_in_division / 100
                 ),
-                "make_playoffs": "{:.1%}".format(
+                "make_playoffs": "{:.1f}%".format(
                     seeding_outcomes.iloc[i].make_playoffs / 100
                 ),
                 "last_in_division": "{:.1%}".format(

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -302,9 +302,6 @@ def get_playoff_odds_df(final_standings: pd.DataFrame) -> pd.DataFrame:
         .rename(columns={"index": "team_id"})
     )
     playoff_odds["playoff_odds"] *= 100 / n
-    playoff_odds["playoff_odds"] = playoff_odds["playoff_odds"].clip(
-        lower=0.1, upper=99.9
-    )
 
     # Get average wins and losses
     playoff_odds["wins"] /= n
@@ -354,9 +351,9 @@ def get_rank_distribution_df(final_standings: pd.DataFrame) -> pd.DataFrame:
         .mean()["made_playoffs"]
         .rename("playoff_odds")
         * 100
-    ).sort_values("playoff_odds", ascending=False)
+    )
 
-    return rank_dist_df
+    return rank_dist_df.sort_values(["playoff_odds", 1], ascending=False)
 
 
 def get_seeding_outcomes_df(final_standings: pd.DataFrame) -> pd.DataFrame:
@@ -413,6 +410,7 @@ def get_seeding_outcomes_df(final_standings: pd.DataFrame) -> pd.DataFrame:
         / n
         * 100
     )
+
     return final_standings_agg.sort_values(
         by=["first_in_league", "first_in_division"], ascending=False
     )

--- a/templates/fantasy_stats/simulation.html
+++ b/templates/fantasy_stats/simulation.html
@@ -109,6 +109,8 @@
         </div>
         {% endfor %}
       <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
+      <br>
+      <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
     </table>
 
     <h2>Final position distribution</h1>
@@ -136,6 +138,8 @@
         </div>
         {% endfor %}
       <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
+      <br>
+      <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
     </table>
 
     <h2>Seeding outcomes</h1>
@@ -165,6 +169,8 @@
         </div>
         {% endfor %}
       <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
+      <br>
+      <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
     </table>
     </div>
     


### PR DESCRIPTION
Remove clipping of all playoff odds and instead leave a disclaimer that simulation results are empirically derived and no not necessarily mean that team has been mathematically eliminated from or clinched the playoffs.