### PR TITLE
feat: Add "remaining strength of schedule" table to sites

### DIFF
--- a/fantasy_stats/views.py
+++ b/fantasy_stats/views.py
@@ -9,6 +9,7 @@ from src.doritostats.django_utils import (
     django_power_rankings,
     django_simulation,
     django_standings,
+    django_strength_of_schedule,
     django_weekly_stats,
     ordinal,
 )
@@ -186,6 +187,7 @@ def league(request, league_id: int, league_year: int, week: int = None):
         weekly_awards = django_weekly_stats(league, week)
         power_rankings = django_power_rankings(league, week)
         luck_index = django_luck_index(league, week)
+        strength_of_schedule = django_strength_of_schedule(league, week)
         standings = django_standings(league)
 
     context = {
@@ -196,6 +198,7 @@ def league(request, league_id: int, league_year: int, week: int = None):
         "weekly_awards": weekly_awards,
         "power_rankings": power_rankings,
         "luck_index": luck_index,
+        "strength_of_schedule": strength_of_schedule,
         "standings": standings,
     }
     return HttpResponse(render(request, "fantasy_stats/league.html", context))
@@ -266,6 +269,7 @@ def simulation(
         "playoff_odds": playoff_odds,
         "rank_dist": rank_dist,
         "seeding_outcomes": seeding_outcomes,
+        "strength_of_schedule": django_strength_of_schedule(league, week),
         "n_positions": len(league.teams),
         "positions": [ordinal(i) for i in range(1, len(league.teams) + 1)],
         "n_playoff_spots": league.settings.playoff_team_count,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.0.16"
+version = "3.0.17"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/django_utils.py
+++ b/src/doritostats/django_utils.py
@@ -1,6 +1,7 @@
 from src.doritostats.simulation_utils import simulate_season
 from espn_api.football import League
 from src.doritostats.analytic_utils import (
+    get_remaining_schedule_difficulty_df,
     sort_lineups_by_func,
     get_best_lineup,
     get_best_trio,
@@ -256,6 +257,40 @@ def django_standings(league: League):
         )
 
     return standings
+
+
+def django_strength_of_schedule(league: League, week: int):
+    """This is a helper function to get the remaining strength of schedule for each team in the league.
+    The results are returned as a list of dictionaries, which is the most conveneint format
+    for django to render.
+
+    Args:
+        league (League): A formatted ESPN league object.
+        week (int): The week to get the remaining strength of schedule for.
+
+    Returns:
+        _type_: _description_
+    """
+    # Get strength of schedule for the current week
+    sos_df = get_remaining_schedule_difficulty_df(league, week)
+
+    # Add the strength of schedule for each team
+    django_sos = []
+    for i in range(len(sos_df)):
+        django_sos.append(
+            {
+                "team": sos_df.iloc[i].name.team_name,
+                "opp_points_for": "{:.1f}".format(sos_df.iloc[i].opp_points_for),
+                "opp_win_pct": "{:.3f}".format(sos_df.iloc[i].opp_win_pct),
+                "opp_power_rank": "{:.1f}".format(sos_df.iloc[i].opp_power_rank),
+                "overall_difficulty": "{:.1f}".format(
+                    sos_df.iloc[i].overall_difficulty
+                ),
+                "owner": sos_df.iloc[i].name.owner,
+            }
+        )
+
+    return django_sos
 
 
 def django_simulation(league: League, n_simulations: int):

--- a/src/doritostats/draft_utils.py
+++ b/src/doritostats/draft_utils.py
@@ -53,7 +53,7 @@ def get_draft_details(league: League) -> pd.DataFrame:
             draft.loc[i, "position"] = player.eligibleSlots[0]
 
     # Map owners of previous/co-owned teams to current owners to preserve "franchise"
-    owner_map = {"Katie Brooks": "Nikki  Pilla"}
+    owner_map = {"Katie Brooks": "Nikki Pilla"}
     draft.replace({"team_owner": owner_map, "opp_owner": owner_map}, inplace=True)
 
     # Add some additional columns

--- a/src/doritostats/fetch_utils.py
+++ b/src/doritostats/fetch_utils.py
@@ -630,7 +630,7 @@ def get_historical_stats(
     df["team_owner"] = df.team_owner.str.title()
 
     # Map owners of previous/co-owned teams to current owners to preserve "franchise"
-    owner_map = {"Katie Brooks": "Nikki  Pilla"}
+    owner_map = {"Katie Brooks": "Nikki Pilla"}
     df.replace({"team_owner": owner_map, "opp_owner": owner_map}, inplace=True)
 
     # Get win streak data for each owner

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -529,9 +529,24 @@ def simulate_season(
                 "points_for",
                 "playoff_odds",
             ]
-        ].sort_values(by="playoff_odds", ascending=False),
-        rank_dist,
-        seeding_outcomes,
+        ].sort_values(
+            by=["playoff_odds", "wins", "points_for", "team_owner"],
+            ascending=[False, False, False, True],
+        ),
+        rank_dist.sort_values(
+            by=["playoff_odds"] + [i + 1 for i in range(len(rank_dist) - 1)],
+            ascending=False,
+        ),
+        seeding_outcomes.sort_values(
+            by=[
+                "make_playoffs",
+                "first_in_league",
+                "first_in_division",
+                "last_in_league",
+                "last_in_division",
+            ],
+            ascending=[False, False, False, True, True],
+        ),
     )
 
 
@@ -595,16 +610,16 @@ def playoff_odds_swing(league: League, week: int, n: int = 100) -> pd.DataFrame:
         # Simulate season if home team wins
         home_team = matchup.home_team
         outcomes_home_win = get_outcomes_if_team_wins(home_team, week, matchups)
-        odds_home_win, _, _ = simulate_season(
+        odds_home_win = simulate_season(
             league, n, what_if=True, outcomes=outcomes_home_win
-        ).set_index("team_owner")
+        )[0].set_index("team_owner")
 
         # Simulate season if away team wins
         away_team = matchup.away_team
         outcomes_away_win = get_outcomes_if_team_wins(away_team, week, matchups)
-        odds_away_win, _, _ = simulate_season(
+        odds_away_win = simulate_season(
             league, n, what_if=True, outcomes=outcomes_away_win
-        ).set_index("team_owner")
+        )[0].set_index("team_owner")
 
         # Merge results
         odds = pd.merge(

--- a/templates/fantasy_stats/league.html
+++ b/templates/fantasy_stats/league.html
@@ -186,6 +186,35 @@
       </div>
     </div>
 
+    {# Remaining strength of schedule #}
+    <div class="wrapper-wide">
+      <h2>Remaining strength of schedule</h2>
+      <table class="table">
+        {# Table header #}
+        <div class="row header">
+          <div class="cell">Team</div>
+          <div class="cell">Owner</div>
+          <div class="cell">Blended difficulty</div>
+          <div class="cell">Opponent's Points For</div>
+          <div class="cell">Opponent's Win %</div>
+          <div class="cell">Opponent's Power Ranking</div>
+        </div>
+
+        {# Table elements #}
+        {% for r in strength_of_schedule %}
+          <div class="row">
+            <div class="cell" data-title="team">{{ r.team }}</div>
+            <div class="cell" data-title="owner">{{ r.owner }}</div>
+            <div class="cell" data-title="blended_difficulty">{{ r.overall_difficulty }}</div>
+            <div class="cell" data-title="opponent_points_for">{{ r.opp_points_for }}</div>
+            <div class="cell" data-title="opponent_win_pct">{{ r.opp_win_pct }}</div>
+            <div class="cell" data-title="opponent_power_ranking">{{ r.opp_power_rank }}</div>
+          </div>
+        {% endfor %}
+        <em>Blended difficulty</em> accounts for the <em>points for</em>, <em>winning %</em>, and <em>power ranking</em> of each team's remaining opponents.
+      </table>
+    </div>
+
     <footer>
       <div class="container">
         <div class="footer-content">

--- a/templates/fantasy_stats/simulation.html
+++ b/templates/fantasy_stats/simulation.html
@@ -92,7 +92,7 @@
     </div>
     
     <div class="wrapper-wide">
-    <h2>Playoff simulation</h1>
+    <h2>Playoff simulation</h2>
     <table class="table">
 
         {# Table header #}
@@ -123,7 +123,7 @@
       <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
     </table>
 
-    <h2>Final position distribution</h1>
+    <h2>Final position distribution</h2>
     <table class="table">
 
         {# Table header #}
@@ -152,7 +152,7 @@
       <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
     </table>
 
-    <h2>Seeding outcomes</h1>
+    <h2>Seeding outcomes</h2>
     <table class="table">
 
         {# Table header #}
@@ -181,6 +181,36 @@
       <b>Note that for this league, {{ n_playoff_spots }} teams make the playoffs.</b>
       <br>
       <em>All playoff odds are based on simulation results alone. Values of 0% or 100% do not necessarily mean that a team has been mathematically eliminated or clinched a playoff spot.</em>
+    </table>
+
+
+
+    <h2>Remaining strength of schedule</h2>
+    <table class="table">
+
+        {# Table header #}
+        <div class="row header">
+          <div class="cell">Team</div>
+          <div class="cell">Owner</div>
+          <div class="cell">Blended difficulty</div>
+          <div class="cell">Opponent's Points For</div>
+          <div class="cell">Opponent's Win %</div>
+          <div class="cell">Opponent's Power Ranking</div>
+        </div>
+
+        {# Table elements #}
+        {% for r in strength_of_schedule %}
+        <div class="row">
+          <div class="cell" data-title="team"> {{ r.team }}</div>
+          <div class="cell" data-title="owner"> {{ r.owner }}</div>
+          <div class="cell" data-title="blended_difficulty"> {{ r.overall_difficulty }}</div>
+          <div class="cell" data-title="opponent_points_for"> {{ r.opp_points_for }}</div>
+          <div class="cell" data-title="opponent_win_pct"> {{ r.opp_win_pct }}</div>
+          <div class="cell" data-title="opponent_power_ranking"> {{ r.opp_power_rank }}</div>
+
+        </div>
+        {% endfor %}
+      <em>Blended difficulty</em> accounts for the <em>points for</em>, <em>winning %</em>, and <em>power ranking</em> of each team's remaining opponents.
     </table>
     </div>
     


### PR DESCRIPTION
Adds a table detailing the remaining strength of schedule for each team. This table is displayed on the league homepage and simulations page.