### PR TITLE
fix: Incorrectly calculating SOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.1.0"
+version = "3.1.1"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -267,6 +267,7 @@ def get_remaining_schedule_difficulty(
 
     """
     remaining_schedule = team.schedule[week - 1 :]
+    n_completed_weeks = len([o for o in team.outcomes if o != "U"])
 
     if strength == "points_for":
         # Get all scores from remaining opponenets through specified week
@@ -275,7 +276,7 @@ def get_remaining_schedule_difficulty(
         ).flatten()
 
         # Exclude weeks that haven't occurred yet (not always applicable)
-        remaining_strength = remaining_strength[remaining_strength > 0]
+        remaining_strength = remaining_strength[:n_completed_weeks]
 
         # Return average score
         return remaining_strength.mean()


### PR DESCRIPTION
I think this fixes an issue. For some leagues, the SOS by all metrics was the same for every metric