### PR TITLE
fix: Rollback previous SOS chage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.1.1"
+version = "3.1.3"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -272,7 +272,7 @@ def get_remaining_schedule_difficulty(
     if strength == "points_for":
         # Get all scores from remaining opponenets through specified week
         remaining_strength = np.array(
-            [opp.scores[: week - 1] for opp in remaining_schedule]
+            [opp.scores[: week - 1][:n_completed_weeks] for opp in remaining_schedule]
         ).flatten()
 
         # Exclude weeks that haven't occurred yet (not always applicable)


### PR DESCRIPTION
I incorrectly fixed a problem that didn't exist. It was just a strange edge case where half the league had the exact same schedule as each other and the other half had the same schedule as each other. This was just a weird coincidence