### PR TITLE
fix: Use `matchup_period` as week

### DIFF
--- a/fantasy_stats/views.py
+++ b/fantasy_stats/views.py
@@ -21,10 +21,11 @@ N_SIMULATIONS = 500
 
 
 def get_default_week(league: League):
+    current_matchup_period = league.settings.week_to_matchup_period[league.current_week]
     if datetime.datetime.now().strftime("%A") in ["Tuesday", "Wednesday"]:
-        return league.current_week - 1
+        return current_matchup_period - 1
     else:
-        return league.current_week
+        return current_matchup_period
 
 
 # Create your views here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.2.1"
+version = "3.3.0"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -1048,9 +1048,10 @@ def season_stats_analysis(
     if week is None:
         week = df.query(f"year == {df.year.max()}").week.max()
 
+    current_matchup_period = league.settings.week_to_matchup_period[league.current_week]
     df = df.query("is_meaningful_game == True")
     df_current_year = df.query(f"year == {league.year}")
-    df_current_week = df_current_year.query(f"week == {league.current_week - 1}")
+    df_current_week = df_current_year.query(f"week == {current_matchup_period - 1}")
 
     print("----------------------------------------------------------------")
     print(

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -470,10 +470,13 @@ def simulate_season(
         first_week_to_simulate = (
             standings[["wins", "ties", "losses"]].sum(axis=1).iloc[0] + 1
         )
+        current_matchup_period = league.settings.week_to_matchup_period[
+            league.current_week
+        ]
         standings, matchups_to_exclude = input_outcomes(
             league=league,
             standings=standings,
-            week=league.current_week,
+            week=current_matchup_period,
             outcomes=outcomes,
         )
     else:


### PR DESCRIPTION
The entire codebase is written to assume that the variable `week` is synonymous with the word `matchup_period`. This is not inherently true, as some matchup periods span multiple weeks. Rather than re-write the entire codebase to use matchup_period, week is instead defined as the matchup_period at the top of the stack.