### PR TITLE
fix: Resolve simulations bug and SOS

### DIFF
--- a/doritostats/urls.py
+++ b/doritostats/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.4.4"
+version = "3.4.5"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -232,6 +232,7 @@ def calculate_win_pct(outcomes: np.array) -> float:
 def get_remaining_schedule_difficulty(
     team: Team,
     week: int,
+    regular_season_length: int,
     strength: str = "points_for",
     league: Optional[League] = None,
 ) -> float:
@@ -250,7 +251,7 @@ def get_remaining_schedule_difficulty(
     if strength == "points_for":
         # Get all scores from remaining opponenets through specified week
         remaining_strength = np.array(
-            [opp.scores[: week - 1][:n_completed_weeks] for opp in remaining_schedule]
+            [opp.scores[:week][:n_completed_weeks] for opp in remaining_schedule]
         ).flatten()
 
         # Exclude weeks that haven't occurred yet (not always applicable)
@@ -262,7 +263,7 @@ def get_remaining_schedule_difficulty(
     elif strength == "win_pct":
         # Get win pct of remaining opponenets through specified week
         remaining_strength = np.array(
-            [opp.outcomes[: week - 1] for opp in remaining_schedule]
+            [opp.outcomes[:week] for opp in remaining_schedule]
         ).flatten()
 
         # Divide # of wins by (# of wins + # of losses) -- this excludes matches that tied or have not occurred yet
@@ -319,20 +320,34 @@ def get_remaining_schedule_difficulty_df(league: League, week: int) -> pd.DataFr
         remaining_difficulty_dict[team] = {}
 
         # SOS by points for
-        remaining_difficulty_dict[team][
-            "opp_points_for"
-        ] = get_remaining_schedule_difficulty(team, week, strength="points_for")
+        remaining_difficulty_dict[team]["opp_points_for"] = (
+            get_remaining_schedule_difficulty(
+                team,
+                week,
+                regular_season_length=league.settings.reg_season_count,
+                strength="points_for",
+            )
+        )
 
         # SOS by win pct
-        remaining_difficulty_dict[team][
-            "opp_win_pct"
-        ] = get_remaining_schedule_difficulty(team, week, strength="win_pct")
+        remaining_difficulty_dict[team]["opp_win_pct"] = (
+            get_remaining_schedule_difficulty(
+                team,
+                week,
+                regular_season_length=league.settings.reg_season_count,
+                strength="win_pct",
+            )
+        )
 
         # SOS by win pct
-        remaining_difficulty_dict[team][
-            "opp_power_rank"
-        ] = get_remaining_schedule_difficulty(
-            team, week, strength="power_rank", league=league
+        remaining_difficulty_dict[team]["opp_power_rank"] = (
+            get_remaining_schedule_difficulty(
+                team,
+                week,
+                regular_season_length=league.settings.reg_season_count,
+                strength="power_rank",
+                league=league,
+            )
         )
 
     # Identify the min and max values for each SOS metric

--- a/src/doritostats/scrape_team_stats.py
+++ b/src/doritostats/scrape_team_stats.py
@@ -234,9 +234,9 @@ def get_stats_by_matchup(
             )
 
             for slot in ["QB", "RB", "WR", "TE", "RB/WR/TE", "D/ST", "K"]:
-                df_week.loc[
-                    i * 2, "{}_pts".format(slot.replace("/", "_"))
-                ] = avg_slot_score(league, home_lineup, slot=slot)
+                df_week.loc[i * 2, "{}_pts".format(slot.replace("/", "_"))] = (
+                    avg_slot_score(league, home_lineup, slot=slot)
+                )
 
                 # Get the best player for each slot
                 top_players = get_top_players(home_lineup, slot, 1)
@@ -244,18 +244,18 @@ def get_stats_by_matchup(
                     # If no player for this position is rostered
                     df_week.loc[i * 2, "best_{}".format(slot.replace("/", "_"))] = 0
                 else:
-                    df_week.loc[
-                        i * 2, "best_{}".format(slot.replace("/", "_"))
-                    ] = top_players[0].points
+                    df_week.loc[i * 2, "best_{}".format(slot.replace("/", "_"))] = (
+                        top_players[0].points
+                    )
                 try:
-                    df_week.loc[
-                        i * 2, "worst_{}".format(slot.replace("/", "_"))
-                    ] = np.min(
-                        [
-                            player.points
-                            for player in get_top_players(home_lineup, slot, 10)
-                            if player.slot_position not in ("BE", "IR")
-                        ]
+                    df_week.loc[i * 2, "worst_{}".format(slot.replace("/", "_"))] = (
+                        np.min(
+                            [
+                                player.points
+                                for player in get_top_players(home_lineup, slot, 10)
+                                if player.slot_position not in ("BE", "IR")
+                            ]
+                        )
                     )
                 except Exception:
                     df_week.loc[i * 2, "worst_{}".format(slot.replace("/", "_"))] = 0
@@ -294,9 +294,9 @@ def get_stats_by_matchup(
                 league, away_lineup
             )
             for slot in ["QB", "RB", "WR", "TE", "RB/WR/TE", "D/ST", "K"]:
-                df_week.loc[
-                    i * 2 + 1, "{}_pts".format(slot.replace("/", "_"))
-                ] = avg_slot_score(league, away_lineup, slot=slot)
+                df_week.loc[i * 2 + 1, "{}_pts".format(slot.replace("/", "_"))] = (
+                    avg_slot_score(league, away_lineup, slot=slot)
+                )
 
                 # Get the best player for each slot
                 top_players = get_top_players(away_lineup, slot, 1)
@@ -304,9 +304,9 @@ def get_stats_by_matchup(
                     # If no player for this position is rostered
                     df_week.loc[i * 2 + 1, "best_{}".format(slot.replace("/", "_"))] = 0
                 else:
-                    df_week.loc[
-                        i * 2 + 1, "best_{}".format(slot.replace("/", "_"))
-                    ] = top_players[0].points
+                    df_week.loc[i * 2 + 1, "best_{}".format(slot.replace("/", "_"))] = (
+                        top_players[0].points
+                    )
             #                 df_week.loc[i*2+1, 'worst_{}'.format(slot.replace('/', '_'))] = np.min([player.points for player in get_top_players(home_lineup, slot, 10) if player.slot_position not in ('BE', 'IR')])
 
             #         df_week.loc[i*2, 'team_record'] = "{}-{}-{}".format(matchup.home_team.wins, matchup.home_team.losses, matchup.home_team.ties)

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -513,6 +513,13 @@ def simulate_season(
         s["division_id"] = team.division_id
         return s
 
+    # Store box_scores function
+    box_scores_func = league.box_scores
+
+    # Set box_scores() to None so that the League object can be pickled
+    league.box_scores = None
+
+    # Run the simulations in parallel
     final_standings = pd.concat(
         Parallel(n_jobs=-1, verbose=1)(
             delayed(simulate_single_season_parallel)() for i in range(n)
@@ -521,6 +528,9 @@ def simulate_season(
     final_standings = (
         final_standings.reset_index().apply(get_team_info, axis=1).set_index("team_id")
     )
+
+    # Restore the box_scores function
+    league.box_scores = box_scores_func
 
     # Get the playoff odds for each team
     playoff_odds = get_playoff_odds_df(final_standings)

--- a/tests/test_luck_index.py
+++ b/tests/test_luck_index.py
@@ -27,7 +27,7 @@ def test_calculate_performance_vs_historical_average(
 ):
     assert luck.calculate_performance_vs_historical_average(
         team_score, team_scores
-    ) == pytest.approx(result, 2)
+    ) == pytest.approx(result, 0.01)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The following was introduced by PR #99 when `League.box_scored()` was cached. This stops the `League` object from being pickle-able when trying to run a function in parallel. This PR resolves this issue by temporarily clearing that function during simulations.

```python
PicklingError at /fantasy_stats/simulation/2023/1086064/n_simulations=250
Could not pickle the task to send it to the workers.
```

There was also a bug in how remaining strength of schedule was calculated that has been fixed.