### PR TITLE
fix: Timestamp issue

### DIFF
--- a/fantasy_stats/email_notifications/email.py
+++ b/fantasy_stats/email_notifications/email.py
@@ -28,10 +28,8 @@ def send_new_league_added_alert(league_info: LeagueInfo):
     year = league_info.league_year
 
     # Convert league_info.creeated_date FROM UTC to EST
-    date_added = (
-        pd.Timestamp(league_info.created_date, tz="UTC")
-        .tz_convert("US/Eastern")
-        .strftime("%B %d, %Y @ %I:%M %p")
+    date_added = league_info.created_date.tz_convert("US/Eastern").strftime(
+        "%B %d, %Y @ %I:%M %p"
     )
 
     # Get the number of new leagues added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.4.8"
+version = "3.4.9"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"


### PR DESCRIPTION
Error when new leagues are created and an email notification is being sent:
```
>>> ValueError: Cannot pass a datetime or Timestamp with tzinfo with the tz parameter. Use tz_convert instead.
>>> File "/app/fantasy_stats/views.py", line 111, in league_input
>>> send_new_league_added_alert(league_info)
>>> File "/app/fantasy_stats/email_notifications/email.py", line 32, in send_new_league_added_alert
>>> pd.Timestamp(league_info.created_date, tz="UTC")
>>> File "pandas/_libs/tslibs/timestamps.pyx", line 1681, in pandas._libs.tslibs.timestamps.Timestamp.__new__
>>> ValueError: Cannot pass a datetime or Timestamp with tzinfo with the tz parameter. Use tz_convert instead.
```