### PR TITLE
fix: simulations error + run faster if season is over

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.4.12"
+version = "3.4.13"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/django_utils.py
+++ b/src/doritostats/django_utils.py
@@ -352,6 +352,9 @@ def django_strength_of_schedule(league: League, week: int):
 
 
 def django_simulation(league: League, n_simulations: int):
+    if league.current_week >= league.settings.reg_season_count:
+        n_simulations = 1
+
     # Get power rankings for the current week
     playoff_odds, rank_dist, seeding_outcomes = simulate_season(league, n=n_simulations)
 

--- a/src/doritostats/simulation_utils.py
+++ b/src/doritostats/simulation_utils.py
@@ -359,7 +359,7 @@ def get_rank_distribution_df(final_standings: pd.DataFrame) -> pd.DataFrame:
     # Calculate the playoff odds for each team and join it to the dataframe
     rank_dist_df = rank_dist_df.join(
         final_standings.groupby(["team_name", "team_id"])
-        .mean()["made_playoffs"]
+        .mean(numeric_only=True)["made_playoffs"]
         .rename("playoff_odds")
         * 100
     )
@@ -518,11 +518,15 @@ def simulate_season(
     league.box_scores = None
 
     # Run the simulations in parallel
-    final_standings = pd.concat(
-        Parallel(n_jobs=-1, verbose=1)(
-            delayed(simulate_single_season_parallel)() for i in range(n)
+    if n > 1:
+        final_standings = pd.concat(
+            Parallel(n_jobs=-1, verbose=1)(
+                delayed(simulate_single_season_parallel)() for i in range(n)
+            )
         )
-    )
+    else:
+        final_standings = simulate_single_season(league, standings)
+
     final_standings = (
         final_standings.reset_index().apply(get_team_info, axis=1).set_index("team_id")
     )


### PR DESCRIPTION
Fix a bug surfacing in the UI:
```python
TypeError at /fantasy_stats/simulation/2023/1086064/n_simulations=250
agg function failed [how->mean,dtype->object]
...
The above exception (Could not convert string 'Vincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent 
ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent 
...
ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent ChiricoVincent Chirico' to numeric) was the direct cause of the following exception:
```

Also, simulations are only runnable for the current week. For previous seasons, the simulations will always return the final standings, and so it is slower and more expensive to run 250+ simulations if they will always return the final standings.