### PR TITLE
fix: Only send email alerts for new leagues

### DIFF
--- a/fantasy_stats/views.py
+++ b/fantasy_stats/views.py
@@ -84,7 +84,11 @@ def league_input(request):
         if league_info_objs:
             league_info = league_info_objs[0]
             league_obj = fetch_league(league_id, league_year, swid, espn_s2)
-            print("League found!")
+            print(
+                "League {} ({}) already exists in the database.".format(
+                    league_id, league_year
+                )
+            )
 
         else:
             print(
@@ -106,6 +110,10 @@ def league_input(request):
                     league_id, league_year
                 )
             )
+
+            # Send an email notification that a new league has been added
+            send_new_league_added_alert(league_info)
+
     except espn_api.requests.espn_requests.ESPNInvalidLeague as e:
         print(
             "League {} ({}) NOT FOUND! ESPN returned an error: {}".format(
@@ -172,9 +180,6 @@ def league_input(request):
                 },
             )
         )
-
-    # Send an email notification that a new league has been added
-    send_new_league_added_alert(league_info)
 
     if league_obj.currentMatchupPeriod <= league_obj.firstScoringPeriod:
         # If the league hasn't started yet, display the "too soon" page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.4.18"
+version = "3.4.19"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"


### PR DESCRIPTION
Email alerts were getting sent even when existing leagues were being added (even though they already existed in the db)