### PR TITLE
fix: Simplify page names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.5.1"
+version = "3.5.2"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/templates/fantasy_stats/season_stats.html
+++ b/templates/fantasy_stats/season_stats.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'fantasy_stats/css/logo.css' %}">
     <link rel="stylesheet" href="{% static 'fantasy_stats/css/footer.css' %}">
     <link rel="shortcut icon" type="image/png" href="{% static 'fantasy_stats/img/favicon.png' %}">
-    <title>Playoff simulation | {{ league_info.league_name }}</title>
+    <title>Season records & leaders</title>
     <style>
       
         .hero {

--- a/templates/fantasy_stats/simulation.html
+++ b/templates/fantasy_stats/simulation.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'fantasy_stats/css/logo.css' %}">
     <link rel="stylesheet" href="{% static 'fantasy_stats/css/footer.css' %}">
     <link rel="shortcut icon" type="image/png" href="{% static 'fantasy_stats/img/favicon.png' %}">
-    <title>Playoff simulation | {{ league_info.league_name }}</title>
+    <title>Playoff simulation</title>
     <style>
       
         .hero {


### PR DESCRIPTION
Remove League ID from page titles to make it easier to see total usage of different page types