### PR TITLE
fix: Worst score & simulations error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.5.2"
+version = "3.5.3"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/analytic_utils.py
+++ b/src/doritostats/analytic_utils.py
@@ -1186,7 +1186,11 @@ def season_stats_analysis(
             ["val", "owners", "val_units", "val_format"],
             [
                 *get_leader_str(
-                    list(df_current_year[["team_owner", "team_score"]].values),
+                    list(
+                        df_current_year[df_current_year["team_score"] > 0][
+                            ["team_owner", "team_score"]
+                        ].values
+                    ),
                     high_first=False,
                 ),
                 "pts",

--- a/src/doritostats/django_utils.py
+++ b/src/doritostats/django_utils.py
@@ -465,7 +465,7 @@ def django_strength_of_schedule(
 
 
 def django_simulation(league: League, n_simulations: int):
-    if league.current_week >= league.settings.reg_season_count:
+    if league.current_week > league.settings.reg_season_count:
         n_simulations = 1
 
     # Get power rankings for the current week


### PR DESCRIPTION
1. The worst score in season records would include weeks that had not been played yet (and had a score of 0)
2. In the final week of the regular season, only a single simulation was being run