### PR TITLE
fix: Only add new leagues if they are active

### DIFF
--- a/fantasy_stats/email_notifications/email.py
+++ b/fantasy_stats/email_notifications/email.py
@@ -29,13 +29,17 @@ def send_new_league_added_alert(league_info: LeagueInfo):
 
     # Get the number of new leagues added
     conn = get_postgres_conn()
-    sql = (
-        "SELECT COUNT(*) FROM public.fantasy_stats_leagueinfo WHERE league_year = 2024"
-    )
-    n_leagues_2024 = pd.read_sql(sql, conn).values[0][0]
-
-    sql = "SELECT COUNT(*) FROM public.fantasy_stats_leagueinfo WHERE created_date > '2024-07-24'"
-    n_leagues_added_this_year = pd.read_sql(sql, conn).values[0][0]
+    n_leagues_2025 = pd.read_sql(
+        "SELECT COUNT(*) FROM public.fantasy_stats_leagueinfo WHERE league_year = 2025",
+        conn,
+    ).values[0][0]
+    n_leagues_added_this_year = pd.read_sql(
+        "SELECT COUNT(*) FROM public.fantasy_stats_leagueinfo WHERE created_date > '2025-03-15'",
+        conn,
+    ).values[0][0]
+    n_leagues_added_all_time = pd.read_sql(
+        "SELECT COUNT(*) FROM public.fantasy_stats_leagueinfo", conn
+    ).values[0][0]
 
     # Fill in the placeholders in the email template
     email_body = MIMEText(
@@ -44,8 +48,9 @@ def send_new_league_added_alert(league_info: LeagueInfo):
             league_id,
             year,
             pd.Timestamp.now(tz="US/Eastern").strftime("%B %d, %Y @ %I:%M %p"),
-            n_leagues_2024,
+            n_leagues_2025,
             n_leagues_added_this_year,
+            n_leagues_added_all_time,
         ),
         "html",
     )

--- a/fantasy_stats/email_notifications/new_league_added.txt
+++ b/fantasy_stats/email_notifications/new_league_added.txt
@@ -6,8 +6,9 @@
         League year: {2}<br>
         Date added:  {3}<br>
         <br>
-        Total 2024 season leagues added: {4}<br>
-        Total leagues added this year:   {5}
+        Total 2025 season leagues added: {4}<br>
+        Total leagues added this year:   {5}<br>
+        Total leagues added all time:    {6}
     </p>
   </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doritostats"
-version = "3.6.0"
+version = "3.6.1"
 description = "This project aims to make ESPN Fantasy Football statistics easily available. With the introduction of version 3 of the ESPN's API, this structure creates leagues, teams, and player classes that allow for advanced data analytics and the potential for many new features to be added."
 authors = ["Desi Pilla <desi.m.pilla@gmail.com>"]
 license = "https://github.com/DesiPilla/espn-api-v3/blob/master/LICENSE"

--- a/src/doritostats/exceptions.py
+++ b/src/doritostats/exceptions.py
@@ -1,0 +1,3 @@
+class InactiveLeagueError(Exception):
+    """Exception raised when a league is inactive."""
+    pass

--- a/src/doritostats/exceptions.py
+++ b/src/doritostats/exceptions.py
@@ -1,3 +1,4 @@
 class InactiveLeagueError(Exception):
     """Exception raised when a league is inactive."""
+
     pass

--- a/templates/fantasy_stats/index.html
+++ b/templates/fantasy_stats/index.html
@@ -103,6 +103,10 @@
           <a class="error-message">
             <em>An unknown error has occurred. Please check that you have entered the correct league ID, SWID, and espn_s2.</em><br>
           </a>
+        {% elif league_id and league_id_inactive %}
+          <a class="error-message">
+            <em>This league has not been activated yet. Please activate the league before adding it here.</em><br>
+          </a>
         {% endif %}
         <br>
         <button type="submit">Fetch league</button>


### PR DESCRIPTION
There is a weird bug in the UI that is somehow copying old leagues that don't actually exist. Now, when a user tries to add a league, it will have to be activated first.