### PR TITLE
Add loading spinners

### DIFF
--- a/frontend/src/components/BoxScoresTable.js
+++ b/frontend/src/components/BoxScoresTable.js
@@ -4,10 +4,15 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const BoxScoresTable = ({ leagueYear, leagueId, week }) => {
+const BoxScoresTable = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [boxScores, setBoxScores] = useState([]);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,7 +21,13 @@ const BoxScoresTable = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchBoxScores = async () => {
-            safeFetch(`/api/box-scores/${leagueYear}/${leagueId}/${week}/`)
+            setLoading(true); // Set internal loading to true
+            safeFetch(
+                `/api/box-scores/${leagueYear}/${leagueId}/${week}/`,
+                {},
+                false,
+                2
+            )
                 .then((data) => {
                     if (data?.redirect) {
                         navigate(data.redirect);
@@ -35,7 +46,7 @@ const BoxScoresTable = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -58,7 +69,7 @@ const BoxScoresTable = ({ leagueYear, leagueId, week }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {loading ? (
+                    {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                         <LoadingRow text="Loading Box Scores..." colSpan="3" />
                     ) : boxScores.length === 0 ? (
                         <tr>

--- a/frontend/src/components/LuckIndexTable.js
+++ b/frontend/src/components/LuckIndexTable.js
@@ -4,10 +4,15 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const LuckIndexTable = ({ leagueYear, leagueId, week }) => {
+const LuckIndexTable = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [luckIndex, setLuckIndex] = useState([]);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,6 +21,7 @@ const LuckIndexTable = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchLuckIndex = () => {
+            setLoading(true); // Set internal loading to true
             safeFetch(
                 `/api/luck-index/${leagueYear}/${leagueId}/${week}/`,
                 {},
@@ -40,7 +46,7 @@ const LuckIndexTable = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -71,7 +77,7 @@ const LuckIndexTable = ({ leagueYear, leagueId, week }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {loading ? (
+                    {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                         <LoadingRow
                             text="Calculating Luck Index..."
                             colSpan="3"

--- a/frontend/src/components/NaughtyList.js
+++ b/frontend/src/components/NaughtyList.js
@@ -4,10 +4,15 @@ import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 import "./styles/spinner.css";
 
-const NaughtyList = ({ leagueYear, leagueId, week }) => {
+const NaughtyList = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [naughtyList, setNaughtyList] = useState([]);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,6 +21,7 @@ const NaughtyList = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchNaughtyList = () => {
+            setLoading(true); // Set internal loading to true
             safeFetch(
                 `/api/naughty-list/${leagueYear}/${leagueId}/${week}/`,
                 {},
@@ -40,7 +46,7 @@ const NaughtyList = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -62,7 +68,7 @@ const NaughtyList = ({ leagueYear, leagueId, week }) => {
                     Please check back on Tuesday morning for the final results.
                 </em>
             </p>
-            {loading ? (
+            {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                 <div className="spinner-container">
                     <div className="spinner"></div>
                     <p>Loading Naughty List...</p>

--- a/frontend/src/components/PowerRankingsTable.js
+++ b/frontend/src/components/PowerRankingsTable.js
@@ -4,10 +4,15 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const PowerRankingsTable = ({ leagueYear, leagueId, week }) => {
+const PowerRankingsTable = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [powerRankings, setPowerRankings] = useState([]);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,7 +21,13 @@ const PowerRankingsTable = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchPowerRankings = () => {
-            safeFetch(`/api/power-rankings/${leagueYear}/${leagueId}/${week}/`)
+            setLoading(true); // Set internal loading to true
+            safeFetch(
+                `/api/power-rankings/${leagueYear}/${leagueId}/${week}/`,
+                {},
+                false,
+                2
+            )
                 .then((data) => {
                     if (data?.redirect) {
                         navigate(data.redirect);
@@ -35,7 +46,7 @@ const PowerRankingsTable = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -66,7 +77,7 @@ const PowerRankingsTable = ({ leagueYear, leagueId, week }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {loading ? (
+                    {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                         <LoadingRow
                             text="Loading Power Rankings..."
                             colSpan="3"

--- a/frontend/src/components/StandingsTable.js
+++ b/frontend/src/components/StandingsTable.js
@@ -4,10 +4,15 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const StandingsTable = ({ leagueYear, leagueId, week }) => {
+const StandingsTable = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [standings, setStandings] = useState([]);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,6 +21,7 @@ const StandingsTable = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchStandings = () => {
+            setLoading(true); // Set internal loading to true
             safeFetch(`/api/standings/${leagueYear}/${leagueId}/${week}/`)
                 .then((data) => {
                     if (data?.redirect) {
@@ -32,7 +38,7 @@ const StandingsTable = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -58,7 +64,7 @@ const StandingsTable = ({ leagueYear, leagueId, week }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {loading ? (
+                    {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                         <LoadingRow text="Loading Standings..." colSpan="6" />
                     ) : standings.length === 0 ? (
                         <tr>

--- a/frontend/src/components/WeekSelector.js
+++ b/frontend/src/components/WeekSelector.js
@@ -3,38 +3,45 @@ import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import './WeekSelector.css';
 
-const WeekSelector = ({ onWeekChange, minWeek, maxWeek, disable = false }) => {
-  const navigate = useNavigate();
+const WeekSelector = ({
+    onWeekChange,
+    minWeek,
+    maxWeek,
+    selectedWeek = null,
+    disable = false,
+}) => {
+    const navigate = useNavigate();
 
-  const selectedWeek = maxWeek - 1;
+    // Ensure selectedWeek is never null
+    selectedWeek = selectedWeek ?? maxWeek - 1;
 
-  const handleChange = (event) => {
-    const newWeek = event.target.value;
-    navigate(`?week=${newWeek}`);
-    onWeekChange(newWeek); // Notify parent component of the week change
-  };
+    const handleChange = (event) => {
+        const newWeek = event.target.value;
+        navigate(`?week=${newWeek}`);
+        onWeekChange(newWeek);
+    };
 
-  return (
-    <div className="select">
-      <select
-        name="league-select"
-        id="league-select"
-        onChange={handleChange}
-        value={selectedWeek}
-        disabled={disable}
-      >
-        {Array.from({ length: maxWeek - minWeek + 1 }, (_, i) => {
-          const week = minWeek + i;
-          return (
-            <option key={week} value={week}>
-              Week {week}
-            </option>
-          );
-        })}
-      </select>
-      <span className="focus"></span>
-    </div>
-  );
+    return (
+        <div className="select">
+            <select
+                name="league-select"
+                id="league-select"
+                onChange={handleChange}
+                value={selectedWeek}
+                disabled={disable}
+            >
+                {Array.from({ length: maxWeek - minWeek + 1 }, (_, i) => {
+                    const week = minWeek + i;
+                    return (
+                        <option key={week} value={week}>
+                            Week {week}
+                        </option>
+                    );
+                })}
+            </select>
+            <span className="focus"></span>
+        </div>
+    );
 };
 
 export default WeekSelector;

--- a/frontend/src/components/WeeklyAwardsTable.js
+++ b/frontend/src/components/WeeklyAwardsTable.js
@@ -4,10 +4,15 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const WeeklyAwardsTable = ({ leagueYear, leagueId, week }) => {
+const WeeklyAwardsTable = ({
+    leagueYear,
+    leagueId,
+    week,
+    loading: globalLoading,
+}) => {
     const [weeklyAwards, setWeeklyAwards] = useState(null);
-    const [loading, setLoading] = useState(true);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Internal loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -16,7 +21,13 @@ const WeeklyAwardsTable = ({ leagueYear, leagueId, week }) => {
 
     useEffect(() => {
         const fetchWeeklyAwards = async () => {
-            safeFetch(`/api/weekly-awards/${leagueYear}/${leagueId}/${week}/`)
+            setLoading(true); // Set internal loading to true
+            safeFetch(
+                `/api/weekly-awards/${leagueYear}/${leagueId}/${week}/`,
+                {},
+                false,
+                2
+            )
                 .then((data) => {
                     if (data?.redirect) {
                         navigate(data.redirect);
@@ -32,7 +43,7 @@ const WeeklyAwardsTable = ({ leagueYear, leagueId, week }) => {
                     setFetchError(err);
                 })
                 .finally(() => {
-                    setLoading(false);
+                    setLoading(false); // Set internal loading to false
                 });
         };
 
@@ -64,7 +75,7 @@ const WeeklyAwardsTable = ({ leagueYear, leagueId, week }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {loading ? (
+                    {globalLoading || loading ? ( // Show spinner if global or internal loading is true
                         <LoadingRow
                             text="Loading Weekly Awards..."
                             colSpan="4"

--- a/frontend/src/components/styles/league.css
+++ b/frontend/src/components/styles/league.css
@@ -1,155 +1,185 @@
-html, body, #root { 
-  margin: 0;
-  font-family: "Helvetica Neue", Helvetica, Arial;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #3b3b3b;
-  background: #b4fb98; /*This is the master background color*/
-  -webkit-font-smoothing: antialiased;
-  min-height: 100vh;
+html,
+body,
+#root {
+    margin: 0;
+    font-family: "Helvetica Neue", Helvetica, Arial;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
+    color: #3b3b3b;
+    background: #b4fb98; /*This is the master background color*/
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
 }
 
 @media screen and (max-width: 580px) {
-
-  /* mobile settings */
-  body {
-    font-size: 16px;
-    line-height: 22px;
-  }
+    /* mobile settings */
+    body {
+        font-size: 16px;
+        line-height: 22px;
+    }
 }
 
 .wrapper {
-  margin: 0 auto;
-  padding: 40px;
-  max-width: 900px;
+    margin: 0 auto;
+    padding: 40px;
+    max-width: 900px;
 }
 
-
 .wrapper-wide {
-  margin: 0 auto;
-  padding: 10px;
-  max-width: 1200px;
+    margin: 0 auto;
+    padding: 10px;
+    max-width: 1200px;
 }
 
 .table {
-  /* margin: 0 auto 40px auto; */
-  margin: 0 0 40px 0;
-  width: 80%;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-  display: table;
+    /* margin: 0 auto 40px auto; */
+    margin: 0 0 40px 0;
+    width: 80%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    display: table;
 }
 
 @media screen and (max-width: 580px) {
-
-  /* mobile settings */
-  .table {
-    display: block;
-    margin: 0 auto 40px auto;
-    width: 80%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-  }
+    /* mobile settings */
+    .table {
+        display: block;
+        margin: 0 auto 40px auto;
+        width: 80%;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
 }
 
 .row {
-  display: table-row;
-  background: #f6f6f6;
+    display: table-row;
+    background: #f6f6f6;
 }
 
 .row:nth-of-type(odd) {
-  background: #d7e0d2;
+    background: #d7e0d2;
 }
 
 .row.header {
-  font-weight: 900;
-  color: #ffffff;
-  background: #333b36;
+    font-weight: 900;
+    color: #ffffff;
+    background: #333b36;
 }
 
 .row.green {
-  background: #27ae60;
+    background: #27ae60;
 }
 
 .row.blue {
-  background: #2980b9;
+    background: #2980b9;
 }
 
 @media screen and (max-width: 580px) {
-  .row {
-    padding: 14px 0 7px;
-    display: block;
-  }
+    .row {
+        padding: 14px 0 7px;
+        display: block;
+    }
 
-  .row.header {
-    padding: 0;
-    height: 6px;
-  }
+    .row.header {
+        padding: 0;
+        height: 6px;
+    }
 
-  .row.header .cell {
-    display: none;
-  }
+    .row.header .cell {
+        display: none;
+    }
 
-  .row .cell {
-    margin-bottom: 10px;
-  }
+    .row .cell {
+        margin-bottom: 10px;
+    }
 
-  .row .cell:before {
-    margin-bottom: 3px;
-    content: attr(data-title);
-    min-width: 98px;
-    font-size: 10px;
-    line-height: 10px;
-    font-weight: bold;
-    text-transform: uppercase;
-    color: #969696;
-    display: block;
-  }
+    .row .cell:before {
+        margin-bottom: 3px;
+        content: attr(data-title);
+        min-width: 98px;
+        font-size: 10px;
+        line-height: 10px;
+        font-weight: bold;
+        text-transform: uppercase;
+        color: #969696;
+        display: block;
+    }
 }
 
 .cell {
-  padding: 6px 12px;
-  display: table-cell;
+    padding: 6px 12px;
+    display: table-cell;
 }
 
 @media screen and (max-width: 580px) {
-  .cell {
-    padding: 2px 16px;
-    display: block;
-  }
+    .cell {
+        padding: 2px 16px;
+        display: block;
+    }
 }
 
 .error-message {
-  color: red;
-  font-weight: bold;
+    color: red;
+    font-weight: bold;
 }
 
 .simulation-button {
-  display: inline-block;
-  padding: 10px 20px;
-  background-color: #2264ff;
-  color: #fff;
-  border: none;
-  border-radius: 5px;
-  text-align: center;
-  text-decoration: none;
-  font-size: 16px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  border: 2px solid #1c54d9;
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #2264ff;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    text-align: center;
+    text-decoration: none;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    border: 2px solid #1c54d9;
 }
 
 .simulation-button:hover {
-  background-color: #1c54d9;
+    background-color: #1c54d9;
 }
 
 .league-content {
-  flex: 1; /* Allow the content to grow and push the footer down */
+    flex: 1; /* Allow the content to grow and push the footer down */
 }
 
 .button-container {
-  display: flex;
-  gap: 10px;
-  justify-content: left;
-  margin: 20px 0;
+    display: flex;
+    gap: 10px;
+    justify-content: left;
+    margin: 20px 0;
+}
+
+.loading-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 10vh;
+}
+
+.loading-spinner {
+    border: 4px solid rgba(0, 0, 0, 0.1); /* Light grey */
+    border-top: 4px solid #3498db; /* Blue accent */
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+.loading-text {
+    margin-left: 12px;
+    font-size: 1.125rem; /* ~18px */
+    color: #333;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
 }

--- a/frontend/src/pages/LeaguePage.js
+++ b/frontend/src/pages/LeaguePage.js
@@ -23,6 +23,7 @@ const LeaguePage = () => {
     const [currentWeek, setCurrentWeek] = useState(null);
     const [leagueSettings, setLeagueSettings] = useState(null);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Add loading state
     const navigate = useNavigate();
 
     if (fetchError) {
@@ -145,14 +146,31 @@ const LeaguePage = () => {
         // Ensure selectedWeek is never undefined
         const validWeek = newWeek ?? currentWeek;
         setSelectedWeek(validWeek);
+        setLoading(true); // Set loading to true when week changes
         const queryParams = new URLSearchParams(location.search);
-        queryParams.set("week", validWeek); // Update the URL query parameter with a valid week
+        queryParams.set("week", validWeek);
         window.history.replaceState(
             null,
             "",
             `${location.pathname}?${queryParams.toString()}`
         );
     };
+
+    useEffect(() => {
+        if (selectedWeek !== null) {
+            // Simulate data fetching for the new week
+            setLoading(true);
+            const fetchData = async () => {
+                try {
+                    // Simulate a delay for fetching data
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                } finally {
+                    setLoading(false); // Set loading to false after data is fetched
+                }
+            };
+            fetchData();
+        }
+    }, [selectedWeek]);
 
     // Fetch the number of playoff teams and update the simulation count if the league is complete
     useEffect(() => {
@@ -200,7 +218,8 @@ const LeaguePage = () => {
                 <p>League ID: {leagueData.league_id}</p>
 
                 <WeekSelector
-                    currentWeek={currentWeek - 1} // Always use currentWeek for WeekSelector
+                    currentWeek={currentWeek} // Always use currentWeek for WeekSelector
+                    selectedWeek={selectedWeek}
                     minWeek={1}
                     maxWeek={currentWeek}
                     onWeekChange={handleWeekChange}
@@ -226,36 +245,42 @@ const LeaguePage = () => {
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
 
                 <WeeklyAwardsTable
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
 
                 <PowerRankingsTable
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
 
                 <LuckIndexTable
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
 
                 <NaughtyList
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
 
                 <StandingsTable
                     leagueYear={leagueYear}
                     leagueId={leagueId}
                     week={selectedWeek}
+                    loading={loading} // Pass loading state
                 />
             </div>
             <Footer />

--- a/frontend/src/pages/LeaguePage.js
+++ b/frontend/src/pages/LeaguePage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import WeekSelector from "../components/WeekSelector";
 import ReturnToHomePageButton from "../components/ReturnToHomePageButton";
@@ -180,9 +180,13 @@ const LeaguePage = () => {
 
         fetchLeagueSettings();
     }, [leagueYear, leagueId]);
-
     if (!leagueData || currentWeek === null) {
-        return <div>Loading...</div>;
+        return (
+            <div className="loading-container">
+                <div className="loading-spinner"></div>
+                <span className="loading-text">Loading league data...</span>
+            </div>
+        );
     }
 
     console.log("Selected week:", selectedWeek);
@@ -260,4 +264,3 @@ const LeaguePage = () => {
 };
 
 export default LeaguePage;
-


### PR DESCRIPTION
* Each table containing stats has a loading spinner while the API fetches the data. However, the LeaguePage cannot render at all until at least the `/api/league-settings/` and `/api/check-league-status` calls finish. This will render a prettier loading spinner for the entire page while the API is called.
* When LeaguePage is first loading, the different tables display a loading spinner until the respective API calls have fetched data. However, when the `selectedWeek` is updated, the loading spinner was not updated. Instead, the Week headers and URL were changed, and then a few seconds later (when the new data was fetched), the tables would update. This fixes that so that the tables display loading spinners when `selectedWeek` is updated.

Playoff simulations are NOT included in this updated (but should later) as they are locked for older seasons and not ready for the current season yet.