### PR TITLE
Frontend updates to `LeagueSimulationsPage` and `SeasonRecordsPage`

### DIFF
--- a/backend/src/doritostats/django_utils.py
+++ b/backend/src/doritostats/django_utils.py
@@ -441,12 +441,10 @@ def django_strength_of_schedule(
         django_sos.append(
             {
                 "team": sos_df.iloc[i].name.team_name,
-                "opp_points_for": "{:.1f}".format(sos_df.iloc[i].opp_points_for),
-                "opp_win_pct": "{:.3f}".format(sos_df.iloc[i].opp_win_pct),
-                "opp_power_rank": "{:.1f}".format(sos_df.iloc[i].opp_power_rank),
-                "overall_difficulty": "{:.1f}".format(
-                    sos_df.iloc[i].overall_difficulty
-                ),
+                "opp_points_for": sos_df.iloc[i].opp_points_for,
+                "opp_win_pct": sos_df.iloc[i].opp_win_pct,
+                "opp_power_rank": sos_df.iloc[i].opp_power_rank,
+                "overall_difficulty": sos_df.iloc[i].overall_difficulty,
                 "owner": sos_df.iloc[i].name.owner,
             }
         )
@@ -477,10 +475,8 @@ def django_simulation(league: League, n_simulations: int, week: Optional[int] = 
                 "projected_wins": playoff_odds.iloc[i].wins,
                 "projected_losses": playoff_odds.iloc[i].losses,
                 "projected_ties": playoff_odds.iloc[i].ties,
-                "projected_points_for": "{:.1f}".format(
-                    playoff_odds.iloc[i].points_for
-                ),
-                "playoff_odds": "{:.1f}%".format(playoff_odds.iloc[i].playoff_odds),
+                "projected_points_for": playoff_odds.iloc[i].points_for,
+                "playoff_odds": playoff_odds.iloc[i].playoff_odds / 100,
             }
         )
 
@@ -490,10 +486,8 @@ def django_simulation(league: League, n_simulations: int, week: Optional[int] = 
             {
                 "team": rank_dist.iloc[i].team_name,
                 "owner": rank_dist.iloc[i].team_owner,
-                "position_odds": [
-                    "{:.1%}".format(rank_dist.iloc[i][c] / 100) for c in rank_cols
-                ],
-                "playoff_odds": "{:.1f}%".format(rank_dist.iloc[i].playoff_odds),
+                "position_odds": [rank_dist.iloc[i][c] / 100 for c in rank_cols],
+                "playoff_odds": rank_dist.iloc[i].playoff_odds / 100,
             }
         )
 
@@ -502,21 +496,11 @@ def django_simulation(league: League, n_simulations: int, week: Optional[int] = 
             {
                 "team": seeding_outcomes.iloc[i].team_name,
                 "owner": seeding_outcomes.iloc[i].team_owner,
-                "first_in_league": "{:.1%}".format(
-                    seeding_outcomes.iloc[i].first_in_league / 100
-                ),
-                "first_in_division": "{:.1%}".format(
-                    seeding_outcomes.iloc[i].first_in_division / 100
-                ),
-                "make_playoffs": "{:.1f}%".format(
-                    seeding_outcomes.iloc[i].make_playoffs
-                ),
-                "last_in_division": "{:.1%}".format(
-                    seeding_outcomes.iloc[i].last_in_division / 100
-                ),
-                "last_in_league": "{:.1%}".format(
-                    seeding_outcomes.iloc[i].last_in_league / 100
-                ),
+                "first_in_league": seeding_outcomes.iloc[i].first_in_league / 100,
+                "first_in_division": seeding_outcomes.iloc[i].first_in_division / 100,
+                "make_playoffs": seeding_outcomes.iloc[i].make_playoffs / 100,
+                "last_in_division": seeding_outcomes.iloc[i].last_in_division / 100,
+                "last_in_league": seeding_outcomes.iloc[i].last_in_league / 100,
             }
         )
 

--- a/backend/src/doritostats/fetch_utils.py
+++ b/backend/src/doritostats/fetch_utils.py
@@ -39,6 +39,7 @@ OWNER_MAP = {
     "Marc Chirico": "Marco Chirico",
 }
 
+
 @contextmanager
 def get_postgres_conn() -> sqlalchemy.engine.base.Connection:
     """Create a postrges connection using the DATABASE_URL environment variable.

--- a/backend/src/doritostats/fetch_utils.py
+++ b/backend/src/doritostats/fetch_utils.py
@@ -36,8 +36,8 @@ OWNER_MAP = {
     "Joseph Ricupero": "Jojo & Matt",
     "Desi Pilla": "Desi & Jane",
     "Marc C": "Marco Chirico",
+    "Marc Chirico": "Marco Chirico",
 }
-
 
 @contextmanager
 def get_postgres_conn() -> sqlalchemy.engine.base.Connection:

--- a/backend/src/doritostats/scrape_player_stats.py
+++ b/backend/src/doritostats/scrape_player_stats.py
@@ -14,6 +14,7 @@ def extract_player_stats(
     df = pd.DataFrame()
     for i, player in enumerate(team_lineup):
         player_data = {
+            "week": week,
             "team_owner": team.owner,
             "team_name": team.team_name,
             "team_division": team.division_name,
@@ -30,7 +31,6 @@ def extract_player_stats(
         }
 
         # Add stat to player_data
-        print(player_data["player_name"], week, player_data["player_active_status"])
         if week in player.stats.keys() and player.active_status != "bye":
             player_data["player_points_week"] = player.stats[week]["points"]
             player_data["player_percent_owned"] = player.percent_owned
@@ -53,7 +53,7 @@ def extract_player_stats(
         else:
             player_data["player_points_season"] = 0
 
-        df = df.append(pd.Series(player_data), ignore_index=True)
+        df = pd.concat([df, pd.Series(player_data).to_frame().T])
 
     return df
 
@@ -110,10 +110,9 @@ def get_stats_by_matchup(
             )
 
             # Append to week data frame
-            df_week = df_week.append(df_home_team)
-            df_week = df_week.append(df_away_team)
+            df_week = pd.concat([df_week, df_home_team, df_away_team])
 
-        df = df.append(df_week)
+        df = pd.concat([df, df_week])
 
     df["league_id"] = league_id
     df["year"] = year

--- a/frontend/src/components/PlayoffOddsTable.js
+++ b/frontend/src/components/PlayoffOddsTable.js
@@ -3,10 +3,26 @@ import PropTypes from 'prop-types';
 import LoadingRow from "./LoadingRow";
 import './styles/tableStyles.css';
 
-const PlayoffOddsTable = ({ data, playoffTeams, selectedWeek }) => {
+const PlayoffOddsTable = ({
+    data,
+    playoffTeams,
+    selectedWeek,
+    pendingData,
+}) => {
     return (
         <div className="wrapper-wide">
             <h2>Playoff Odds (prior to Week {selectedWeek} matchups)</h2>
+            {pendingData && ( // Only display note if week > nCompletedWeeks
+                <p>
+                    <em>
+                        Note that scores have not yet been finalized for this
+                        week and the playoff odds are likely to change.
+                        <br />
+                        Please check back on Tuesday morning for the final
+                        results.
+                    </em>
+                </p>
+            )}
             <table className="table-with-bottom-caption">
                 <thead>
                     <tr>
@@ -21,29 +37,44 @@ const PlayoffOddsTable = ({ data, playoffTeams, selectedWeek }) => {
                 </thead>
                 <tbody>
                     {data === null || playoffTeams === null ? (
-                        <LoadingRow text="Calculating playoff odds..." colSpan="7" />
+                        <LoadingRow
+                            text="Calculating playoff odds..."
+                            colSpan="7"
+                        />
                     ) : (
                         data.map((team, index) => (
-                            <tr key={index} className={index % 2 === 0 ? "even-row" : "odd-row"}>
-                                <td className="team-name-column">{team.team}</td>
-                                <td className="team-name-column">{team.owner}</td>
-                                <td>{team.projected_wins}</td>
-                                <td>{team.projected_losses}</td>
-                                <td>{team.projected_ties}</td>
-                                <td>{team.projected_points_for}</td>
-                                <td>{team.playoff_odds}</td>
+                            <tr
+                                key={index}
+                                className={
+                                    index % 2 === 0 ? "even-row" : "odd-row"
+                                }
+                            >
+                                <td className="team-name-column">
+                                    {team.team}
+                                </td>
+                                <td className="team-name-column">
+                                    {team.owner}
+                                </td>
+                                <td>{team.projected_wins.toFixed(1)}</td>
+                                <td>{team.projected_losses.toFixed(1)}</td>
+                                <td>{team.projected_ties.toFixed(1)}</td>
+                                <td>{team.projected_points_for.toFixed(2)}</td>
+                                <td>{(team.playoff_odds * 100).toFixed(1)}%</td>
                             </tr>
                         ))
                     )}
                 </tbody>
             </table>
             <p>
-                <strong>Note that for this league, {playoffTeams} teams make the playoffs.</strong>
+                <strong>
+                    Note that for this league, {playoffTeams} teams make the
+                    playoffs.
+                </strong>
                 <br />
                 <em>
-                All playoff odds are based on simulation results alone.
-                Values of 0% or 100% do not necessarily mean that a team
-                has been mathematically eliminated or clinched a playoff spot.
+                    All playoff odds are based on simulation results alone.
+                    Values of 0% or 100% do not necessarily mean that a team has
+                    been mathematically eliminated or clinched a playoff spot.
                 </em>
             </p>
         </div>

--- a/frontend/src/components/RankDistributionTable.js
+++ b/frontend/src/components/RankDistributionTable.js
@@ -3,16 +3,45 @@ import PropTypes from 'prop-types';
 import LoadingRow from "./LoadingRow";
 import './styles/tableStyles.css';
 
-const RankDistributionTable = ({ data, numColumns, playoffTeams, selectedWeek }) => {
+const RankDistributionTable = ({
+    data,
+    numColumns,
+    playoffTeams,
+    selectedWeek,
+    pendingData,
+}) => {
     const ordinalSuffix = (num) => {
         const suffixes = ["th", "st", "nd", "rd"];
         const value = num % 100;
-        return num + (suffixes[(value - 20) % 10] || suffixes[value] || suffixes[0]);
+        return (
+            num +
+            (suffixes[(value - 20) % 10] || suffixes[value] || suffixes[0])
+        );
     };
+
+    function formatPercent(val) {
+        const percentage = val * 100;
+        return `${percentage.toFixed(val < 0.1 ? 1 : 0)}%`;
+    }
 
     return (
         <div className="wrapper-wide">
-            <h2>Final position distribution odds (prior to Week {selectedWeek} matchups)</h2>
+            <h2>
+                Final position distribution odds (prior to Week {selectedWeek}{" "}
+                matchups)
+            </h2>
+            {pendingData && ( // Only display note if week > nCompletedWeeks
+                <p>
+                    <em>
+                        Note that scores have not yet been finalized for this
+                        week and the final position distributions are likely to
+                        change.
+                        <br />
+                        Please check back on Tuesday morning for the final
+                        results.
+                    </em>
+                </p>
+            )}
             <table className="table-with-bottom-caption">
                 <thead>
                     <tr>
@@ -26,28 +55,45 @@ const RankDistributionTable = ({ data, numColumns, playoffTeams, selectedWeek })
                 </thead>
                 <tbody>
                     {data === null ? (
-                        <LoadingRow text="Calculating rank distribution..." colSpan={numColumns + 3} />
+                        <LoadingRow
+                            text="Calculating rank distribution..."
+                            colSpan={numColumns + 3}
+                        />
                     ) : (
                         data.map((team, index) => (
-                            <tr key={index} className={index % 2 === 0 ? "even-row" : "odd-row"}>
-                                <td className="team-name-column">{team.team}</td>
-                                <td className="team-name-column">{team.owner}</td>
-                                {team.position_odds.slice(0, numColumns).map((odds, i) => (
-                                    <td key={i}>{odds}</td>
-                                ))}
-                                <td>{team.playoff_odds}</td>
+                            <tr
+                                key={index}
+                                className={
+                                    index % 2 === 0 ? "even-row" : "odd-row"
+                                }
+                            >
+                                <td className="team-name-column">
+                                    {team.team}
+                                </td>
+                                <td className="team-name-column">
+                                    {team.owner}
+                                </td>
+                                {team.position_odds
+                                    .slice(0, numColumns)
+                                    .map((odds, i) => (
+                                        <td key={i}>{formatPercent(odds)}</td>
+                                    ))}
+                                <td>{formatPercent(team.playoff_odds)}</td>
                             </tr>
                         ))
                     )}
                 </tbody>
             </table>
             <p>
-                <strong>Note that for this league, {playoffTeams} teams make the playoffs.</strong>
+                <strong>
+                    Note that for this league, {playoffTeams} teams make the
+                    playoffs.
+                </strong>
                 <br />
                 <em>
-                All percentages are based on simulation results alone.
-                Values of 0% or 100% do not necessarily mean that a team
-                has been mathematically eliminated or clinched a playoff spot.
+                    All percentages are based on simulation results alone.
+                    Values of 0% or 100% do not necessarily mean that a team has
+                    been mathematically eliminated or clinched a playoff spot.
                 </em>
             </p>
         </div>

--- a/frontend/src/components/RemainingStrengthOfScheduleTable.js
+++ b/frontend/src/components/RemainingStrengthOfScheduleTable.js
@@ -5,7 +5,12 @@ import LoadingRow from "./LoadingRow";
 import { safeFetch } from "../utils/api";
 import "./styles/tableStyles.css";
 
-const RemainingStrengthOfScheduleTable = ({ leagueId, leagueYear, week }) => {
+const RemainingStrengthOfScheduleTable = ({
+    leagueId,
+    leagueYear,
+    week,
+    nCompletedWeeks,
+}) => {
     const [
         remainingStrengthOfScheduleData,
         setRemainingStrengthOfScheduleData,
@@ -65,6 +70,18 @@ const RemainingStrengthOfScheduleTable = ({ leagueId, leagueYear, week }) => {
                         : ` for Weeks ${minWeek}-${maxWeek}` // Show range if minWeek and maxWeek are different
                     : ""}
             </h2>
+            {minWeek > nCompletedWeeks && ( // Only display note if minWeek > nCompletedWeeks
+                <p>
+                    <em>
+                        Note that scores have not yet been finalized for this
+                        week and the Remaining Strengths of Schedule are likely
+                        to change.
+                        <br />
+                        Please check back on Tuesday morning for the final
+                        results.
+                    </em>
+                </p>
+            )}
             <table className="table-with-bottom-caption">
                 <thead>
                     <tr>
@@ -96,10 +113,10 @@ const RemainingStrengthOfScheduleTable = ({ leagueId, leagueYear, week }) => {
                                 <td className="team-name-column">
                                     {team.owner}
                                 </td>
-                                <td>{team.opp_points_for}</td>
-                                <td>{team.opp_win_pct}</td>
-                                <td>{team.opp_power_rank}</td>
-                                <td>{team.overall_difficulty}</td>
+                                <td>{team.opp_points_for.toFixed(2)}</td>
+                                <td>{team.opp_win_pct.toFixed(3)}</td>
+                                <td>{team.opp_power_rank.toFixed(1)}</td>
+                                <td>{team.overall_difficulty.toFixed(1)}</td>
                             </tr>
                         ))
                     )}

--- a/frontend/src/components/SeasonPositionalRecordsTable.js
+++ b/frontend/src/components/SeasonPositionalRecordsTable.js
@@ -7,7 +7,10 @@ const SeasonPositionalRecordsTable = ({ bestPositionalStats, worstPositionalStat
     return (
         <div className="wrapper-wide">
             <h2>Season Positional Records</h2>
-            <table className="table-with-bottom-caption">
+            <table
+                className="table-with-bottom-caption"
+                style={{ tableLayout: "fixed", width: "70%" }}
+            >
                 <thead>
                     <tr>
                         <th>Award</th>
@@ -17,11 +20,19 @@ const SeasonPositionalRecordsTable = ({ bestPositionalStats, worstPositionalStat
                 </thead>
                 <tbody>
                     {!bestPositionalStats || !worstPositionalStats ? (
-                        <LoadingRow text="Loading positional records..." colSpan="3" />
+                        <LoadingRow
+                            text="Loading positional records..."
+                            colSpan="3"
+                        />
                     ) : (
                         <>
                             {bestPositionalStats.map((stat, index) => (
-                                <tr key={`best-${index}`} className={index % 2 === 0 ? "even-row" : "odd-row"}>
+                                <tr
+                                    key={`best-${index}`}
+                                    className={
+                                        index % 2 === 0 ? "even-row" : "odd-row"
+                                    }
+                                >
                                     <td>{stat.label}</td>
                                     <td>{stat.owner}</td>
                                     <td>{stat.value}</td>
@@ -30,7 +41,9 @@ const SeasonPositionalRecordsTable = ({ bestPositionalStats, worstPositionalStat
                             {worstPositionalStats.map((stat, index) => (
                                 <tr
                                     key={`worst-${index}`}
-                                    className={`${index === 0 ? "thick-border-top" : ""} ${
+                                    className={`${
+                                        index === 0 ? "thick-border-top" : ""
+                                    } ${
                                         index % 2 === 0 ? "even-row" : "odd-row"
                                     }`}
                                 >

--- a/frontend/src/components/SeasonTeamRecordsTable.js
+++ b/frontend/src/components/SeasonTeamRecordsTable.js
@@ -7,7 +7,10 @@ const SeasonTeamRecordsTable = ({ bestTeamStats, worstTeamStats }) => {
     return (
         <div className="wrapper-wide">
             <h2>Season Team Records</h2>
-            <table className="table-with-bottom-caption">
+            <table
+                className="table-with-bottom-caption"
+                style={{ tableLayout: "fixed", width: "70%" }}
+            >
                 <thead>
                     <tr>
                         <th>Award</th>
@@ -17,11 +20,19 @@ const SeasonTeamRecordsTable = ({ bestTeamStats, worstTeamStats }) => {
                 </thead>
                 <tbody>
                     {!bestTeamStats || !worstTeamStats ? (
-                        <LoadingRow text="Loading team records..." colSpan="3" />
+                        <LoadingRow
+                            text="Loading team records..."
+                            colSpan="3"
+                        />
                     ) : (
                         <>
                             {bestTeamStats.map((stat, index) => (
-                                <tr key={`best-${index}`} className={index % 2 === 0 ? "even-row" : "odd-row"}>
+                                <tr
+                                    key={`best-${index}`}
+                                    className={
+                                        index % 2 === 0 ? "even-row" : "odd-row"
+                                    }
+                                >
                                     <td>{stat.label}</td>
                                     <td>{stat.owner}</td>
                                     <td>{stat.value}</td>
@@ -30,7 +41,9 @@ const SeasonTeamRecordsTable = ({ bestTeamStats, worstTeamStats }) => {
                             {worstTeamStats.map((stat, index) => (
                                 <tr
                                     key={`worst-${index}`}
-                                    className={`${index === 0 ? "thick-border-top" : ""} ${
+                                    className={`${
+                                        index === 0 ? "thick-border-top" : ""
+                                    } ${
                                         index % 2 === 0 ? "even-row" : "odd-row"
                                     }`}
                                 >

--- a/frontend/src/components/SeedingOutcomesTable.js
+++ b/frontend/src/components/SeedingOutcomesTable.js
@@ -3,10 +3,26 @@ import PropTypes from 'prop-types';
 import LoadingRow from "./LoadingRow";
 import './styles/tableStyles.css';
 
-const SeedingOutcomesTable = ({ data, playoffTeams }) => {
+const SeedingOutcomesTable = ({ data, playoffTeams, pendingData }) => {
+    function formatPercent(val) {
+        const percentage = val * 100;
+        return `${percentage.toFixed(val < 0.1 ? 1 : 0)}%`;
+    }
+
     return (
         <div className="wrapper-wide">
             <h2>Seeding Outcomes</h2>
+            {pendingData && ( // Only display note if week > nCompletedWeeks
+                <p>
+                    <em>
+                        Note that scores have not yet been finalized for this
+                        week and the seeding outcomes are likely to change.
+                        <br />
+                        Please check back on Tuesday morning for the final
+                        results.
+                    </em>
+                </p>
+            )}
             <table className="table-with-bottom-caption">
                 <thead>
                     <tr>
@@ -21,29 +37,44 @@ const SeedingOutcomesTable = ({ data, playoffTeams }) => {
                 </thead>
                 <tbody>
                     {data === null ? (
-                        <LoadingRow text="Calculating seeding outcomes..." colSpan="7" />
+                        <LoadingRow
+                            text="Calculating seeding outcomes..."
+                            colSpan="7"
+                        />
                     ) : (
                         data.map((team, index) => (
-                            <tr key={index} className={index % 2 === 0 ? "even-row" : "odd-row"}>
-                                <td className="team-name-column">{team.team}</td>
-                                <td className="team-name-column">{team.owner}</td>
-                                <td>{team.first_in_league}</td>
-                                <td>{team.first_in_division}</td>
-                                <td>{team.make_playoffs}</td>
-                                <td>{team.last_in_division}</td>
-                                <td>{team.last_in_league}</td>
+                            <tr
+                                key={index}
+                                className={
+                                    index % 2 === 0 ? "even-row" : "odd-row"
+                                }
+                            >
+                                <td className="team-name-column">
+                                    {team.team}
+                                </td>
+                                <td className="team-name-column">
+                                    {team.owner}
+                                </td>
+                                <td>{formatPercent(team.first_in_league)}</td>
+                                <td>{formatPercent(team.first_in_division)}</td>
+                                <td>{formatPercent(team.make_playoffs)}</td>
+                                <td>{formatPercent(team.last_in_division)}</td>
+                                <td>{formatPercent(team.last_in_league)}</td>
                             </tr>
                         ))
                     )}
                 </tbody>
             </table>
             <p>
-                <strong>Note that for this league, {playoffTeams} teams make the playoffs.</strong>
+                <strong>
+                    Note that for this league, {playoffTeams} teams make the
+                    playoffs.
+                </strong>
                 <br />
                 <em>
-                All percentages are based on simulation results alone.
-                Values of 0% or 100% do not necessarily mean that a team
-                has been mathematically eliminated or clinched a playoff spot.
+                    All percentages are based on simulation results alone.
+                    Values of 0% or 100% do not necessarily mean that a team has
+                    been mathematically eliminated or clinched a playoff spot.
                 </em>
             </p>
         </div>

--- a/frontend/src/pages/LeagueSimulationPage.js
+++ b/frontend/src/pages/LeagueSimulationPage.js
@@ -19,9 +19,13 @@ const LeagueSimulationPage = () => {
     const [simulationData, setSimulationData] = useState(null);
     const [selectedWeek, setSelectedWeek] = useState(null);
     const [currentWeek, setCurrentWeek] = useState(null);
+    const [nCompletedWeeks, setNCompletedWeeks] = useState(null);
     const [leagueSettings, setLeagueSettings] = useState(null);
     const [fetchError, setFetchError] = useState(null);
+    const [loading, setLoading] = useState(false); // Add loading state
     const navigate = useNavigate();
+
+    const MIN_WEEK_TO_SIMULATE = 4; // Minimum week required to run simulations
 
     if (fetchError) {
         throw fetchError;
@@ -124,22 +128,17 @@ const LeagueSimulationPage = () => {
     // Set the default current week and selected week
     useEffect(() => {
         const queryParams = new URLSearchParams(location.search);
-        const weekFromUrl = queryParams.get("week");
+        const weekFromUrl = (() => {
+            const week = queryParams.get("week");
+            return week && !isNaN(parseInt(week)) ? parseInt(week) : null;
+        })();
 
-        console.log("weekFromUrl:", weekFromUrl); // Debugging step
-
-        const validWeekFromUrl =
-            weekFromUrl && !isNaN(parseInt(weekFromUrl, 10))
-                ? parseInt(weekFromUrl, 10)
-                : null;
-
-        if (validWeekFromUrl !== null) {
-            console.log("Setting selected week from URL:", validWeekFromUrl);
-            setSelectedWeek(validWeekFromUrl);
+        if (weekFromUrl) {
+            console.log("Setting selected week from URL:", weekFromUrl);
+            setSelectedWeek(weekFromUrl);
         }
 
-        const fetchCurrentWeek = () => {
-            console.log("Fetching current week...");
+        const fetchCurrentWeek = async () => {
             safeFetch(
                 `/api/league/${leagueYear}/${leagueId}/current-week/`,
                 {},
@@ -148,50 +147,31 @@ const LeagueSimulationPage = () => {
             )
                 .then((data) => {
                     if (data?.redirect) {
-                        console.log(`Redirecting to: ${data.redirect}`);
                         navigate(data.redirect);
-                        return; // Stop further processing if redirect
-                    }
-
-                    console.log("Fetched current week:", data.current_week); // Debugging step
-
-                    const validCurrentWeek = !isNaN(data.current_week)
-                        ? data.current_week
-                        : null;
-                    const validMaxWeek = !isNaN(
-                        leagueSettings?.n_regular_season_weeks
-                    )
-                        ? leagueSettings.n_regular_season_weeks
-                        : validCurrentWeek;
-
-                    const adjustedWeek =
-                        validCurrentWeek !== null
-                            ? Math.min(validMaxWeek, validCurrentWeek)
-                            : null;
-
-                    setCurrentWeek(adjustedWeek);
-
-                    if (
-                        validWeekFromUrl === null &&
-                        validCurrentWeek !== null
-                    ) {
-                        setSelectedWeek(adjustedWeek); // Only set selectedWeek if not defined by URL
+                    } else {
+                        setCurrentWeek(data.current_week);
+                        setNCompletedWeeks(data.n_completed_weeks);
+                        if (!weekFromUrl) {
+                            setSelectedWeek(data.current_week - 1); // Only set selectedWeek if not already defined
+                        }
+                        console.log("Current week:", currentWeek);
+                        console.log("Selected week:", selectedWeek);
+                        console.log(
+                            "Number of completed weeks:",
+                            data.n_completed_weeks
+                        );
                     }
                 })
                 .catch((err) => {
                     console.error(
-                        "ERROR: /api/league/%s/%s/current-week/",
-                        leagueYear,
-                        leagueId,
+                        `ERROR: /api/league/${leagueYear}/${leagueId}/current-week/`,
                         err
                     );
                     setFetchError(err);
                 });
         };
 
-        if (leagueYear && leagueId) {
-            fetchCurrentWeek();
-        }
+        fetchCurrentWeek();
 
         // Ensure selectedWeek is never undefined
         if (selectedWeek === undefined) {
@@ -199,11 +179,11 @@ const LeagueSimulationPage = () => {
                 "selectedWeek is undefined, setting it to currentWeek:",
                 currentWeek
             );
-            setSelectedWeek(currentWeek);
+            setSelectedWeek(currentWeek - 1);
         }
     }, [location.search, leagueYear, leagueId, selectedWeek, currentWeek]);
 
-    // Redirect to "uh-oh-too-early" page if selectedWeek or currentWeek is less than 4
+    // Redirect to "uh-oh-too-early" page if selectedWeek or currentWeek is less than MIN_WEEK_TO_SIMULATE
     useEffect(() => {
         console.log("selectedWeek:", selectedWeek, "currentWeek:", currentWeek);
 
@@ -218,7 +198,10 @@ const LeagueSimulationPage = () => {
 
         // Perform redirect if both weeks are valid
         if (selectedWeek !== null && currentWeek !== null) {
-            if (selectedWeek < 4 || currentWeek < 4) {
+            if (
+                selectedWeek < MIN_WEEK_TO_SIMULATE ||
+                currentWeek < MIN_WEEK_TO_SIMULATE
+            ) {
                 const redirectUrl = `/fantasy_stats/uh-oh-too-early/league-homepage/${leagueYear}/${leagueId}`;
                 console.log(`Redirecting to: ${redirectUrl}`);
                 navigate(redirectUrl);
@@ -269,6 +252,7 @@ const LeagueSimulationPage = () => {
         // Ensure selectedWeek is never undefined
         const validWeek = newWeek && !isNaN(newWeek) ? newWeek : currentWeek;
         console.log("Valid week determined in handleWeekChange:", validWeek); // Debugging step
+
         if (validWeek !== undefined && !isNaN(validWeek)) {
             setSelectedWeek(validWeek);
             setSimulationData(null); // Reset simulationData to show the spinner
@@ -294,9 +278,34 @@ const LeagueSimulationPage = () => {
         );
     };
 
+    useEffect(() => {
+        if (selectedWeek !== null) {
+            // Simulate data fetching for the new week
+            setLoading(true);
+            const fetchData = async () => {
+                try {
+                    // Simulate a delay for fetching data
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                } finally {
+                    setLoading(false); // Set loading to false after data is fetched
+                }
+            };
+            fetchData();
+        }
+    }, [selectedWeek]);
+
     console.log("Selected week:", selectedWeek);
     console.log("Current week:", currentWeek);
     console.log("Number of simulations:", nSimulations);
+
+    if (!leagueSettings || currentWeek === null) {
+        return (
+            <div className="loading-container">
+                <div className="loading-spinner"></div>
+                <span className="loading-text">Loading league data...</span>
+            </div>
+        );
+    }
 
     return (
         <div>
@@ -305,13 +314,14 @@ const LeagueSimulationPage = () => {
             <p>League ID: {leagueId}</p>
 
             <WeekSelector
-                currentWeek={currentWeek ?? 18}
-                onWeekChange={handleWeekChange}
-                minWeek={4}
+                currentWeek={currentWeek}
+                selectedWeek={selectedWeek}
+                minWeek={MIN_WEEK_TO_SIMULATE}
                 maxWeek={Math.min(
                     leagueSettings?.n_regular_season_weeks,
                     currentWeek
                 )}
+                onWeekChange={handleWeekChange}
                 disable={leagueSettings?.regular_season_complete}
             />
 
@@ -336,23 +346,27 @@ const LeagueSimulationPage = () => {
                 data={simulationData?.playoff_odds || null}
                 playoffTeams={leagueSettings?.n_playoff_spots}
                 selectedWeek={selectedWeek}
+                pendingData={selectedWeek >= nCompletedWeeks}
             />
 
             <RankDistributionTable
                 data={simulationData?.rank_distribution || null}
                 numColumns={leagueSettings?.n_teams}
                 playoffTeams={leagueSettings?.n_playoff_spots}
+                pendingData={selectedWeek >= nCompletedWeeks}
             />
 
             <SeedingOutcomesTable
                 data={simulationData?.seeding_outcomes || null}
                 playoffTeams={leagueSettings?.n_playoff_spots}
+                pendingData={selectedWeek >= nCompletedWeeks}
             />
 
             <RemainingStrengthOfScheduleTable
                 leagueYear={leagueYear}
                 leagueId={leagueId}
                 week={selectedWeek}
+                nCompletedWeeks={nCompletedWeeks}
             />
 
             <Footer />


### PR DESCRIPTION
* Update the `OWNERS_MAP` with Marco's new name
* Add `week` when scraping player data
* Fix bug when appending series to dataframes
* Updates to the league simulations page
    * Make a variable `MIN_WEEK_TO_SIMULATE` to hold this value
    * Add a spinner for the entire page while settings are fetched so that page loads instantly (even if there is no data yet)
    * Fix bug with the `WeekSelector` where the selected week in the dropdown did not update when changed
    * Add a `pendingData` variable to the tables indicating if the data is complete or not
    * Move number formating out of the backend API and into the frontend
* Update the season record tables' width